### PR TITLE
IHDL-190/Green blue scale down

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1178,6 +1178,7 @@
     "github.com/golang/protobuf/ptypes/timestamp",
     "github.com/stretchr/testify/assert",
     "gopkg.in/yaml.v1",
+    "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/kubernetes",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,7 +15,7 @@
   name = "github.com/Azure/go-ansiterm"
   packages = [
     ".",
-    "winterm",
+    "winterm"
   ]
   pruneopts = "UT"
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
@@ -100,7 +100,7 @@
     "gettext",
     "gettext/mo",
     "gettext/plural",
-    "gettext/po",
+    "gettext/po"
   ]
   pruneopts = "UT"
   revision = "bf70f2a70fb1b1f36d90d671a72795984eab0fcb"
@@ -118,7 +118,7 @@
   name = "github.com/databus23/helm-diff"
   packages = [
     "diff",
-    "manifest",
+    "manifest"
   ]
   pruneopts = "UT"
   revision = "77dc4f5b84e84692dac22a6fac76aa385d15c2b0"
@@ -137,7 +137,7 @@
   name = "github.com/docker/distribution"
   packages = [
     "digestset",
-    "reference",
+    "reference"
   ]
   pruneopts = "UT"
   revision = "2461543d988979529609e8cb6fca9ca190dc48da"
@@ -158,7 +158,7 @@
     "api/types/swarm",
     "api/types/versions",
     "pkg/term",
-    "pkg/term/windows",
+    "pkg/term/windows"
   ]
   pruneopts = "UT"
   revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
@@ -186,7 +186,7 @@
   name = "github.com/docker/spdystream"
   packages = [
     ".",
-    "spdy",
+    "spdy"
   ]
   pruneopts = "UT"
   revision = "6480d4af844c189cf5dd913db24ddd339d3a4f85"
@@ -266,7 +266,7 @@
     "syntax/ast",
     "syntax/lexer",
     "util/runes",
-    "util/strings",
+    "util/strings"
   ]
   pruneopts = "UT"
   revision = "5ccd90ef52e1e632236f7326478d4faa74f99438"
@@ -277,7 +277,7 @@
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys",
+    "sortkeys"
   ]
   pruneopts = "UT"
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
@@ -307,7 +307,7 @@
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
   pruneopts = "UT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
@@ -342,7 +342,7 @@
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions",
+    "extensions"
   ]
   pruneopts = "UT"
   revision = "0c5108395e2debce0d731cf0287ddf7242066aba"
@@ -353,7 +353,7 @@
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache",
+    "diskcache"
   ]
   pruneopts = "UT"
   revision = "3befbb6ad0cc97d4c25d851e9528915809e1a22f"
@@ -363,7 +363,7 @@
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru",
+    "simplelru"
   ]
   pruneopts = "UT"
   revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
@@ -416,7 +416,7 @@
   packages = [
     "buffer",
     "jlexer",
-    "jwriter",
+    "jwriter"
   ]
   pruneopts = "UT"
   revision = "1ea4449da9834f4d333f1cc461c374aea217d249"
@@ -549,7 +549,7 @@
     "ed25519/internal/edwards25519",
     "pbkdf2",
     "scrypt",
-    "ssh/terminal",
+    "ssh/terminal"
   ]
   pruneopts = "UT"
   revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
@@ -565,7 +565,7 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace",
+    "trace"
   ]
   pruneopts = "UT"
   revision = "65e2d4e15006aab9813ff8769e768bbf4bb667a0"
@@ -578,7 +578,7 @@
     "google",
     "internal",
     "jws",
-    "jwt",
+    "jwt"
   ]
   pruneopts = "UT"
   revision = "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
@@ -589,7 +589,7 @@
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows",
+    "windows"
   ]
   pruneopts = "UT"
   revision = "9f0b1ff7b46a4014ddb5d4bdb6602a43b882cb27"
@@ -620,7 +620,7 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width",
+    "width"
   ]
   pruneopts = "UT"
   revision = "c942b20a5d85b458c4dce1589326051d85e25d6d"
@@ -646,7 +646,7 @@
     "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch",
+    "urlfetch"
   ]
   pruneopts = "UT"
   revision = "54a98f90d1c46b7731eb8fb305d2a321c30ef610"
@@ -696,7 +696,7 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap",
+    "tap"
   ]
   pruneopts = "UT"
   revision = "25c4f928eaa6d96443009bd842389fb4fa48664e"
@@ -717,7 +717,7 @@
     ".",
     "cipher",
     "json",
-    "jwt",
+    "jwt"
   ]
   pruneopts = "UT"
   revision = "730df5f748271903322feb182be83b43ebbbe27d"
@@ -775,7 +775,7 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1",
+    "storage/v1beta1"
   ]
   pruneopts = "UT"
   revision = "b503174bad5991eb66f18247f52e41c3258f6348"
@@ -845,7 +845,7 @@
     "pkg/watch",
     "third_party/forked/golang/json",
     "third_party/forked/golang/netutil",
-    "third_party/forked/golang/reflect",
+    "third_party/forked/golang/reflect"
   ]
   pruneopts = "UT"
   revision = "eddba98df674a16931d2d4ba75edc3a389bf633a"
@@ -861,7 +861,7 @@
     "pkg/authentication/user",
     "pkg/endpoints/request",
     "pkg/features",
-    "pkg/util/feature",
+    "pkg/util/feature"
   ]
   pruneopts = "UT"
   revision = "92fdef3a232a23afb9644f6151119b5961b9feab"
@@ -874,7 +874,7 @@
   packages = [
     "pkg/genericclioptions",
     "pkg/genericclioptions/printers",
-    "pkg/genericclioptions/resource",
+    "pkg/genericclioptions/resource"
   ]
   pruneopts = "UT"
   revision = "11047e25a94a7eaa541b92a8bbfd3e1243607219"
@@ -959,7 +959,7 @@
     "util/homedir",
     "util/integer",
     "util/jsonpath",
-    "util/retry",
+    "util/retry"
   ]
   pruneopts = "UT"
   revision = "d082d5923d3cc0bfbb066ee5fbdea3d0ca79acf8"
@@ -984,7 +984,7 @@
     "pkg/renderutil",
     "pkg/storage/errors",
     "pkg/sympath",
-    "pkg/version",
+    "pkg/version"
   ]
   pruneopts = "UT"
   revision = "618447cbf203d147601b4b9bd7f8c37a5d39fbb4"
@@ -996,7 +996,7 @@
   name = "k8s.io/kube-openapi"
   packages = [
     "pkg/util/proto",
-    "pkg/util/proto/validation",
+    "pkg/util/proto/validation"
   ]
   pruneopts = "UT"
   revision = "6b3d3b2d5666c5912bab8b7bf26bf50f75a8f887"
@@ -1145,7 +1145,7 @@
     "pkg/util/parsers",
     "pkg/util/slice",
     "pkg/util/taints",
-    "pkg/version",
+    "pkg/version"
   ]
   pruneopts = "UT"
   revision = "435f92c719f279a3a67808c80521ea17d5715c66"
@@ -1156,7 +1156,7 @@
   name = "k8s.io/utils"
   packages = [
     "exec",
-    "pointer",
+    "pointer"
   ]
   pruneopts = "UT"
   revision = "c2654d5206da6b7b6ace12841e8f359bb89b443c"
@@ -1178,19 +1178,20 @@
     "github.com/golang/protobuf/ptypes/timestamp",
     "github.com/stretchr/testify/assert",
     "gopkg.in/yaml.v1",
-    "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/kubernetes/typed/apps/v1",
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/util/retry",
     "k8s.io/helm/pkg/helm",
     "k8s.io/helm/pkg/helm/portforwarder",
     "k8s.io/helm/pkg/proto/hapi/release",
     "k8s.io/helm/pkg/proto/hapi/services",
-    "k8s.io/helm/pkg/storage/errors",
+    "k8s.io/helm/pkg/storage/errors"
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cli/app.go
+++ b/cli/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Hutchison-Technologies/helm-deployer/runtime"
 	"github.com/databus23/helm-diff/diff"
 	"github.com/databus23/helm-diff/manifest"
+	appv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/helm/pkg/helm"
@@ -73,6 +74,12 @@ func editChartValues(valuesYaml *yaml.Yaml, settings [][]interface{}) []byte {
 
 func kubeCtlClient() v1.CoreV1Interface {
 	client, err := kubectl.Client()
+	runtime.PanicIfError(err)
+	return client
+}
+
+func kubeCtlAppClient() appv1.AppsV1Interface {
+	client, err := kubectl.AppsClient()
 	runtime.PanicIfError(err)
 	return client
 }

--- a/cli/bluegreen.go
+++ b/cli/bluegreen.go
@@ -10,6 +10,9 @@ import (
 	"github.com/Hutchison-Technologies/helm-deployer/filesystem"
 	"github.com/Hutchison-Technologies/helm-deployer/k8s"
 	"github.com/Hutchison-Technologies/helm-deployer/runtime"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 func BlueGreenFlags() []*Flag {
@@ -85,6 +88,33 @@ func RunBlueGreenDeploy() error {
 		cliFlags[CHART_DIR])
 	log.Printf("Successfully deployed %s, the service is now live!", Green(serviceDeploymentName))
 	PrintRelease(deployedServiceRelease)
+
+	log.Println("To reduce costing, number of pods in offline deployments will now be scaled to zero.")
+	currentOfflineColour := determineDeployColour(cliFlags[TARGET_ENV], cliFlags[APP_NAME])
+	deploymentsClient := kubeCtlAppClient().Deployments(apiv1.NamespaceDefault)
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Build string to search for
+		offlineDeploymentName := deployment.BlueGreenDeploymentName(cliFlags[TARGET_ENV], currentOfflineColour, cliFlags[APP_NAME])
+
+		// Retrieve the latest version of Deployment before attempting update
+		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+
+		result, getErr := deploymentsClient.Get(offlineDeploymentName, metav1.GetOptions{})
+		if getErr != nil {
+			panic(fmt.Errorf("Failed to get latest version of Deployment: %v", getErr))
+		}
+
+		var numberOfReplicas int32 = 0
+		result.Spec.Replicas = &numberOfReplicas
+		_, updateErr := deploymentsClient.Update(result)
+		return updateErr
+	})
+	if retryErr != nil {
+		panic(fmt.Errorf("Update failed: %v", retryErr))
+	}
+	log.Println("Updated deployment scaling to zero replicas...")
+	log.Println("Updates complete!")
+
 	return nil
 }
 

--- a/cli/bluegreen.go
+++ b/cli/bluegreen.go
@@ -98,7 +98,6 @@ func RunBlueGreenDeploy() error {
 
 		// Retrieve the latest version of Deployment before attempting update
 		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-
 		result, getErr := deploymentsClient.Get(offlineDeploymentName, metav1.GetOptions{})
 		if getErr != nil {
 			panic(fmt.Errorf("Failed to get latest version of Deployment: %v", getErr))
@@ -106,13 +105,20 @@ func RunBlueGreenDeploy() error {
 
 		var numberOfReplicas int32 = 0
 		result.Spec.Replicas = &numberOfReplicas
+
 		_, updateErr := deploymentsClient.Update(result)
 		return updateErr
 	})
+
 	if retryErr != nil {
 		panic(fmt.Errorf("Update failed: %v", retryErr))
 	}
 	log.Println("Updated deployment scaling to zero replicas...")
+
+	//HPA update here if we get errors.
+	//Fetch HPA offlineDeploymentName-hpa
+	//Update result.spec.minReplicas: 0, result.spec.maxReplicas: 0
+
 	log.Println("Updates complete!")
 
 	return nil

--- a/kubectl/kubectl.go
+++ b/kubectl/kubectl.go
@@ -2,20 +2,30 @@ package kubectl
 
 import (
 	"fmt"
+	"os"
+
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/typed/core/v1"
+	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"k8s.io/helm/pkg/helm/portforwarder"
-	"os"
 )
 
-func Client() (v1.CoreV1Interface, error) {
+func Client() (corev1.CoreV1Interface, error) {
 	_, client, err := getKubeClient()
 	if err != nil {
 		return nil, err
 	}
 	return client.CoreV1(), nil
+}
+
+func AppsClient() (appsv1.AppsV1Interface, error) {
+	_, client, err := getKubeClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.AppsV1(), nil
 }
 
 func SetupTillerTunnel() (string, error) {


### PR DESCRIPTION
- Added in new kubectl client to deal with "apps", this allows access to deployments.
- Fetches "new" offline service after toggling the old offline service to online, and scales the replica set to zero. 
- Uses an exponential back off retry, does not overwrite the whole file. Just tries to update single line so we don't have merge conflict issues from the file being modified by a different deployment.